### PR TITLE
Add support for comment tokens in assembler

### DIFF
--- a/src/lib/assembler.ts
+++ b/src/lib/assembler.ts
@@ -170,9 +170,7 @@ function readToken(state: CodeState): Token | Error {
   }
 
   if (char(state) === "#") {
-    /** Sign for Comment */
-    while(!state.reachedEnd && state.index < state.code.length && state.code[state.index] != '\n')
-      advance(state)
+    while (!state.reachedEnd && state.code[state.index] != "\n") advance(state)
   }
 
   if (state.reachedEnd) {
@@ -359,12 +357,6 @@ export function assemble(
       }
     }
   }
-
-  console.log({
-    kind: "result",
-    data,
-    executionInfo,
-  })
 
   return {
     kind: "result",


### PR DESCRIPTION
Introduce functionality for comment tokens that can start at the beginning of a line and allow comments to be added after instructions on the same line.

as written in #7 